### PR TITLE
Eliminación servicio tRPC estadísticas

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: Preview
-      url: https://your-accounts-preview.vercel.app/
+      url: ${{ steps.vercel-deploy.outputs.PREVIEW_URL }}
     if: "${{ (!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.ref_name, 'main')) }}"
     steps:
       - name: Checkout
@@ -36,8 +36,6 @@ jobs:
             PUBLIC_FIREBASE_OPTIONS=${{ vars.FIREBASE_OPTIONS }}
             PUBLIC_ENV=preview
             JWT_SECRET=${{ vars.JWT_SECRET }}
-          ALIAS_DOMAINS: |
-            {REPO}-preview.vercel.app
       - name: Comment PR
         uses: thollander/actions-comment-pull-request@v2
         if: ${{ steps.vercel-deploy.outputs.DEPLOYMENT_CREATED }}

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: Production
-      url: http://your-accounts.vercel.app/
+      url: https://your-accounts.vercel.app/
     if: "${{ !contains(github.event.head_commit.message, '[skip ci]') }}"
     steps:
       - name: Checkout

--- a/src/lib/components/budget/DetailsItem.svelte
+++ b/src/lib/components/budget/DetailsItem.svelte
@@ -85,7 +85,7 @@
 	</section>
 
 	<Select id={`${prefixFieldName}.category`} name={`${prefixFieldName}.category`} label="Categoría">
-		<option value="" disabled selected>Seleccione</option>
+		<option value={null} disabled selected>Seleccione</option>
 		<option value={BudgetBillCategory.HOUSE}>Hogar</option>
 		<option value={BudgetBillCategory.ENTERTAINMENT}>Entretenimiento</option>
 		<option value={BudgetBillCategory.PERSONAL}>Personal</option>

--- a/src/lib/components/shared/Header.svelte
+++ b/src/lib/components/shared/Header.svelte
@@ -69,7 +69,7 @@
 					<div class="w-10 rounded-full">
 						<!-- svelte-ignore a11y-img-redundant-alt -->
 						<img
-							src={$session?.photoURL || 'http://www.gravatar.com/avatar/?d=mp'}
+							src={$session?.photoURL || 'https://www.gravatar.com/avatar/?d=mp'}
 							alt="Profile Photo"
 						/>
 					</div>

--- a/src/lib/components/shared/ScreenLoading.svelte
+++ b/src/lib/components/shared/ScreenLoading.svelte
@@ -3,10 +3,15 @@
 </script>
 
 {#if $screenLoading}
-	<section class="z-[2000] fixed inset-0 bg-black bg-opacity-30 flex justify-center items-center">
-		<span class="loading loading-ring loading-xs text-primary" />
-		<span class="loading loading-ring loading-sm text-primary" />
-		<span class="loading loading-ring loading-md text-primary" />
-		<span class="loading loading-ring loading-lg text-primary" />
+	<section
+		class="z-[2000] fixed inset-0 bg-black bg-opacity-30 flex flex-col justify-center items-center gap-2"
+	>
+		<i class="bx bxs-wallet text-6xl text-primary animate-pulse" />
+		<section class="flex justify-center items-center">
+			<span class="loading loading-ring loading-xs text-primary" />
+			<span class="loading loading-ring loading-sm text-primary" />
+			<span class="loading loading-ring loading-md text-primary" />
+			<span class="loading loading-ring loading-lg text-primary" />
+		</section>
 	</section>
 {/if}

--- a/src/lib/components/shared/navbar/NavbarItem.svelte
+++ b/src/lib/components/shared/navbar/NavbarItem.svelte
@@ -5,8 +5,8 @@
 </script>
 
 <div class="basis-full tooltip tooltip-top" data-tip={text}>
-	<a class="tab w-full gap-x-2" {href} class:tab-active={active}>
+	<a class="tab w-full gap-x-2 text-lg" {href} class:tab-active={active}>
 		<slot />
-		<span class="hidden sm:block">{text}</span>
+		<span class="hidden sm:block text-sm">{text}</span>
 	</a>
 </div>

--- a/src/lib/trpc/routes/budgets.ts
+++ b/src/lib/trpc/routes/budgets.ts
@@ -1,16 +1,9 @@
 import { BudgetBillCategory } from '$lib/enums'
 import { t } from '../t'
-import type {
-	Budget,
-	BudgetBillShared,
-	BudgetBillTransaction,
-	BudgetMinimal,
-	BudgetStatistics
-} from '$lib/types'
+import type { Budget, BudgetBillShared, BudgetBillTransaction, BudgetMinimal } from '$lib/types'
 import z, { defaultNumber, defaultString } from '$utils/zod.utils'
 import delay from 'delay'
 import { procedure } from '../middleware'
-import { categoryTranslate } from '$utils/i18n'
 
 const availables = t.router({
 	create: procedure
@@ -221,23 +214,6 @@ export const budgets = t.router({
 			projectId: 2
 		}
 		return budget
-	}),
-	getStatisticsById: procedure.input(defaultNumber).query(async () => {
-		await delay(1000)
-
-		const categories = Object.values(BudgetBillCategory).map((category) =>
-			categoryTranslate(category)
-		) as string[]
-		const statistics: BudgetStatistics = {
-			categories,
-			amount: {
-				data: [100000, 1350000, 55000, 2000000, 87420, 100000, 1800000, 80000]
-			},
-			payment: {
-				data: [0, 0, 60000, 400000, 0, 100000, 0, 10000]
-			}
-		}
-		return statistics
 	}),
 	delete: procedure.input(defaultNumber).mutation(async () => {
 		await delay(1000)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,11 +65,9 @@ export type BudgetBillShared = {
 
 export type BudgetStatistics = {
 	categories: string[]
-	amount: {
-		data: number[]
-	}
-	payment: {
-		data: number[]
+	data: {
+		amount: number[]
+		payment: number[]
 	}
 }
 

--- a/src/routes/(app)/budget/[id]/+layout.svelte
+++ b/src/routes/(app)/budget/[id]/+layout.svelte
@@ -51,10 +51,11 @@
 		totalAvailable
 	})
 
-	const { bills, totals } = billsDataStore(data.bills)
+	const { bills, totals, statistics } = billsDataStore(data.bills)
 	setContext(ContextNameEnum.BUDGET_BILLS, {
 		bills,
-		totals
+		totals,
+		statistics
 	})
 
 	async function handleSave() {
@@ -64,15 +65,13 @@
 				changes.delete(changeList)
 				const sendChanges: Change<unknown>[] = []
 
-				const groupBySection = groupBy<Change<unknown>>(changeList, (change) => change.section)
+				const groupBySection = groupBy(changeList, (change) => change.section)
 				Object.entries(groupBySection).forEach((group) => {
 					const [section, items] = group
-					const groupByAction = groupBy<Change<unknown>>(items, (change) => change.action)
+					const groupByAction = groupBy(items, (change) => change.action)
 					Object.entries(groupByAction).forEach((group) => {
 						const [action, items] = group
-						const groupById = groupBy<Change<unknown>>(items, (change) =>
-							change.detail.id.toString()
-						)
+						const groupById = groupBy(items, (change) => change.detail.id.toString())
 						Object.entries(groupById).forEach((group) => {
 							const [id, items] = group
 


### PR DESCRIPTION
Se elimina el servicio en las rutas de tRPC para consulta de estadísticas de un presupuesto y se reemplaza por calculos con los mismos datos de los pagos que se tienen en el contexto de la página.